### PR TITLE
Cambio de palabra por su  sinónimo

### DIFF
--- a/docs/xamarin-forms/data-cloud/index.md
+++ b/docs/xamarin-forms/data-cloud/index.md
@@ -22,7 +22,7 @@ Para obtener una introducción al consumo del servicio web entre plataformas en 
 
 ## <a name="understanding-the-samplexamarin-formsdata-cloudwalkthroughmd"></a>[Descripción del ejemplo](~/xamarin-forms/data-cloud/walkthrough.md)
 
-Este artículo ofrece un tutorial de la aplicación de ejemplo de Xamarin.Forms que muestra cómo comunicar con los servicios web diferentes. Los temas tratados son la Anatomía de la aplicación, el modelo de datos, páginas e invocar operaciones del servicio web.
+Este artículo ofrece un tutorial de la aplicación de ejemplo de Xamarin.Forms que muestra cómo comunicar con los servicios web diferentes. Los temas tratados son la Anatomía de la aplicación, el modelo de datos, páginas e solicitar operaciones del servicio web.
 
 ## <a name="consuming-web-servicesxamarin-formsdata-cloudconsumingindexmd"></a>[Consumo de servicios web](~/xamarin-forms/data-cloud/consuming/index.md)
 


### PR DESCRIPTION
En el pequeño párrafo utilizamos un sinónimo para mayor a claridad de entendimiento